### PR TITLE
fix: switch to use from the framework

### DIFF
--- a/src/stubs/controller/api-stub.ts
+++ b/src/stubs/controller/api-stub.ts
@@ -1,7 +1,7 @@
 import { Controller } from '{{namespace}}Controller'
 import { {{storeRequestClass}} } from '{{requestNamespace}}{{storeRequest}}'
 import { {{updateRequestClass}} } from '{{requestNamespace}}{{updateRequest}}'
-import { use } from '@formidablejs/ts-ports'
+import { use } from '@formidablejs/framework'
 import type { Response } from '@formidablejs/framework'
 
 export class {{class}} extends Controller {

--- a/src/stubs/controller/resource-stub.ts
+++ b/src/stubs/controller/resource-stub.ts
@@ -1,7 +1,7 @@
 import { Controller } from '{{namespace}}Controller'
 import { {{storeRequestClass}} } from '{{requestNamespace}}{{storeRequest}}'
 import { {{updateRequestClass}} } from '{{requestNamespace}}{{updateRequest}}'
-import { use } from '@formidablejs/ts-ports'
+import { use } from '@formidablejs/framework'
 import type { Response } from '@formidablejs/framework'
 
 export class {{class}} extends Controller {


### PR DESCRIPTION
<!-- This is adapted from github.com/imba/imba -->

<!-- Provide a general summary of your changes in the Title above -->

## Description
Use `use` from `@formidablejs/framework` instead of `@formidablejs/ts-ports`
<!-- Describe your changes in detail -->

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran manual tests.

<!-- Please describe in detail how you tested your changes. -->

<!-- Include details of your testing environment, tests ran to see how -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
